### PR TITLE
Cleaned up snippet descriptions and allowed scope

### DIFF
--- a/anchor.sublime-snippet
+++ b/anchor.sublime-snippet
@@ -5,5 +5,6 @@ anchor('${1:url}', '${2:linkname}', '${3:attributs}');
    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
    <tabTrigger>anchor</tabTrigger>
    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-   <!-- <scope>source.php</scope> -->
+   <scope>source.php, source.php.embedded.block.html</scope>
+   <description>CI - Anchor Helper</description>
 </snippet>

--- a/calendar.sublime-snippet
+++ b/calendar.sublime-snippet
@@ -12,5 +12,6 @@ echo \$this->calendar->generate(${5:year}, ${6:month}, \$data);
    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
    <tabTrigger>calendar</tabTrigger>
    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-   <!-- <scope>source.php</scope> -->
+   <scope>source.php, source.php.embedded.block.html</scope>
+   <description>CI - Calendar Helper</description>
 </snippet>

--- a/cart_add.sublime-snippet
+++ b/cart_add.sublime-snippet
@@ -13,5 +13,6 @@
    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
    <tabTrigger>cart_add</tabTrigger>
    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-   <!-- <scope>source.php</scope> -->
+   <scope>source.php</scope>
+   <description>CI - Add to Cart</description>
 </snippet>

--- a/cart_update.sublime-snippet
+++ b/cart_update.sublime-snippet
@@ -10,5 +10,6 @@
    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
    <tabTrigger>cart_update</tabTrigger>
    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-   <!-- <scope>source.php</scope>-->
+   <scope>source.php</scope>
+   <description>CI - Update Cart</description>
 </snippet>

--- a/ci_start.sublime-snippet
+++ b/ci_start.sublime-snippet
@@ -2,11 +2,14 @@
     <content><![CDATA[
 <?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
 
+$0
+
 /* End of file ${1:filename}.php */
 /* Location: ./application/${2:folder}/${3:filename}.php */
 ]]></content>
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>ci_start</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <!-- <scope>source.python</scope> -->
+    <scope>source.php</scope>
+    <description>CI - Generic Starter Class</description>
 </snippet>

--- a/construct.sublime-snippet
+++ b/construct.sublime-snippet
@@ -3,11 +3,12 @@
 public function __construct()
 {
    parent::__construct();
-   ${1://Do your magic here}
+   ${0://Do your magic here}
 }
 ]]></content>
    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
    <tabTrigger>construct</tabTrigger>
    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-   <!-- <scope>source.php</scope> -->
+   <scope>source.php</scope>
+   <description>CI - Class Constructor</description>
 </snippet>

--- a/controller.sublime-snippet
+++ b/controller.sublime-snippet
@@ -6,6 +6,7 @@ class ${1:${TM_FILENAME/(.+)\..+|.*/\u$1/:Controllername}} extends ${2:CI}_Contr
 
     public function index()
     {
+        $0
     }
 
 }
@@ -16,5 +17,6 @@ class ${1:${TM_FILENAME/(.+)\..+|.*/\u$1/:Controllername}} extends ${2:CI}_Contr
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>controller</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <!-- <scope>source.php</scope> -->
+    <scope>source.php</scope>
+    <description>CI - Base Controller</description>
 </snippet>

--- a/crud.sublime-snippet
+++ b/crud.sublime-snippet
@@ -1,12 +1,13 @@
 <snippet>
    <content><![CDATA[
 <?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
-class ${1:Controllername} extends CI_Controller {
+
+class ${1:${TM_FILENAME/(.+)\..+|.*/\u$1/:Controllername}} extends ${2:CI}_Controller {
 
    public function __construct()
    {
       parent::__construct();
-      //Load Dependencies
+      ${0://Load Dependencies}
 
    }
 
@@ -34,9 +35,13 @@ class ${1:Controllername} extends CI_Controller {
 
    }
 }
+
+/* End of file ${1/(.+)/\l$1/:Controllername}.php */
+/* Location: ./application/controllers/${1/(.+)/\l$1/:Controllername}.php */
 ]]></content>
    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
    <tabTrigger>crud</tabTrigger>
    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-   <!-- <scope>source.python</scope> -->
+   <scope>source.php</scope>
+   <description>CI - Simple CRUD Controller</description>
 </snippet>

--- a/db_delete.sublime-snippet
+++ b/db_delete.sublime-snippet
@@ -6,5 +6,5 @@
     <tabTrigger>db_delete</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
     <scope>source.php</scope>
-    <description>Active Record DB Delete</description>
+    <description>CI - Active Record DB Delete</description>
 </snippet>

--- a/db_get.sublime-snippet
+++ b/db_get.sublime-snippet
@@ -6,6 +6,6 @@
     <tabTrigger>db_get</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
     <scope>source.php</scope>
-    <description>Active Record DB Get</description>
+    <description>CI - Active Record DB Get</description>
 
 </snippet>

--- a/db_insert.sublime-snippet
+++ b/db_insert.sublime-snippet
@@ -6,5 +6,5 @@
     <tabTrigger>db_insert</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
     <scope>source.php</scope>
-    <description>Active Record DB Insert</description>
+    <description>CI - Active Record DB Insert</description>
 </snippet>

--- a/db_select.sublime-snippet
+++ b/db_select.sublime-snippet
@@ -6,5 +6,5 @@
     <tabTrigger>db_select</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
     <scope>source.php</scope>
-    <description>Active Record DB Select</description>
+    <description>CI - Active Record DB Select</description>
 </snippet>

--- a/db_update.sublime-snippet
+++ b/db_update.sublime-snippet
@@ -6,5 +6,5 @@
     <tabTrigger>db_update</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
     <scope>source.php</scope>
-    <description>Active Record DB Update</description>
+    <description>CI - Active Record DB Update</description>
 </snippet>

--- a/db_where.sublime-snippet
+++ b/db_where.sublime-snippet
@@ -6,5 +6,5 @@
     <tabTrigger>db_where</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
     <scope>source.php</scope>
-    <description>Active Record DB Where</description>
+    <description>CI - Active Record DB Where</description>
 </snippet>

--- a/display_cart.sublime-snippet
+++ b/display_cart.sublime-snippet
@@ -11,7 +11,7 @@
   <th style="text-align:right">Sub-Total</th>
 </tr>
 
-<?php $i = 1; ?>
+<?php \$i = 1; ?>
 
 <?php foreach (\$this->cart->contents() as \$items): ?>
 
@@ -36,7 +36,7 @@
 
      </td>
      <td style="text-align:right"><?php echo \$this->cart->format_number(\$items['price']); ?></td>
-     <td style="text-align:right">$<?php echo \$this->cart->format_number(\$items['subtotal']); ?></td>
+     <td style="text-align:right">\$<?php echo \$this->cart->format_number(\$items['subtotal']); ?></td>
    </tr>
 
 <?php \$i++; ?>
@@ -46,7 +46,7 @@
 <tr>
   <td colspan="2"> </td>
   <td class="right"><strong>Total</strong></td>
-  <td class="right">$<?php echo \$this->cart->format_number(\$this->cart->total()); ?></td>
+  <td class="right">\$<?php echo \$this->cart->format_number(\$this->cart->total()); ?></td>
 </tr>
 
 </table>
@@ -56,5 +56,6 @@
    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
    <tabTrigger>display_cart</tabTrigger>
    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-   <!--<scope>source.php</scope> -->
+   <scope>source.php, text.html</scope>
+   <description>CI - Simple Cart Template</description>
 </snippet>

--- a/email.sublime-snippet
+++ b/email.sublime-snippet
@@ -17,5 +17,6 @@ echo \$this->email->print_debugger();
    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
    <tabTrigger>email</tabTrigger>
    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-   <!-- <scope>source.php</scope> -->
+   <scope>source.php</scope>
+   <description>CI - Email Boilerplate</description>
 </snippet>

--- a/form_checkbox.sublime-snippet
+++ b/form_checkbox.sublime-snippet
@@ -5,5 +5,6 @@ form_checkbox(${1:name}, ${2:value}, TRUE);
    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
    <tabTrigger>form_checkbox</tabTrigger>
    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-   <!-- <scope>source.php</scope> -->
+   <scope>source.php, source.php.embedded.block.html</scope>
+   <description>CI - Form Helper - Checkbox</description>
 </snippet>

--- a/form_dropdown.sublime-snippet
+++ b/form_dropdown.sublime-snippet
@@ -5,5 +5,6 @@ form_dropdown('${1:name}', \$options, '${2:default}');
    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
    <tabTrigger>form_dropdown</tabTrigger>
    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-   <!-- <scope>source.php</scope> -->
+   <scope>source.php, source.php.embedded.block.html</scope>
+   <description>CI - Form Helper - Dropdown</description>
 </snippet>

--- a/form_hidden.sublime-snippet
+++ b/form_hidden.sublime-snippet
@@ -5,5 +5,6 @@ form_hidden('${1:name}', '${2:value}');
    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
    <tabTrigger>form_hidden</tabTrigger>
    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-   <!-- <scope>source.python</scope> -->
+   <scope>source.php, source.php.embedded.block.html</scope>
+   <description>CI - Form Helper - Hidden Field</description>
 </snippet>

--- a/form_input.sublime-snippet
+++ b/form_input.sublime-snippet
@@ -5,5 +5,6 @@ form_input('${1:name}', '${2:value}', '${3:attributs}');
    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
    <tabTrigger>form_input</tabTrigger>
    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-   <!-- <scope>source.php</scope> -->
+   <scope>source.php, source.php.embedded.block.html</scope>
+   <description>CI - Form Helper - Input Field</description>
 </snippet>

--- a/form_open.sublime-snippet
+++ b/form_open.sublime-snippet
@@ -5,5 +5,6 @@ form_open('${1:url}', '', \$hidden);
    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
    <tabTrigger>form_open</tabTrigger>
    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-   <!-- <scope>source.php</scope> -->
+   <scope>source.php, source.php.embedded.block.html</scope>
+   <description>CI - Form Open</description>
 </snippet>

--- a/form_password.sublime-snippet
+++ b/form_password.sublime-snippet
@@ -5,5 +5,6 @@ form_password('${1:name}', '${2:value}');
    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
    <tabTrigger>form_password</tabTrigger>
    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-   <!-- <scope>source.php</scope> -->
+   <scope>source.php, source.php.embedded.block.html</scope>
+   <description>CI - Form Helper - Password Field</description>
 </snippet>

--- a/form_submit.sublime-snippet
+++ b/form_submit.sublime-snippet
@@ -5,5 +5,6 @@ form_submit('${1:name}', '${2:value}');
    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
    <tabTrigger>form_submit</tabTrigger>
    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-   <!-- <scope>source.php</scope> -->
+   <scope>source.php, source.php.embedded.block.html</scope>
+   <description>CI - Form Helper - Submit</description>
 </snippet>

--- a/form_textarea.sublime-snippet
+++ b/form_textarea.sublime-snippet
@@ -5,5 +5,6 @@ form_textarea('${1:name}', '${2:value}', '${3:attributs}');
    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
    <tabTrigger>form_textarea</tabTrigger>
    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-   <!-- <scope>source.php</scope> -->
+   <scope>source.php, source.php.embedded.block.html</scope>
+   <description>CI - Form Helper - Text Area</description>
 </snippet>

--- a/form_upload.sublime-snippet
+++ b/form_upload.sublime-snippet
@@ -5,5 +5,6 @@ form_upload('${1:name}');
    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
    <tabTrigger>form_upload</tabTrigger>
    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-   <!-- <scope>source.php</scope> -->
+   <scope>source.php, source.php.embedded.block.html</scope>
+   <description>CI - Form Helper - Upload Field</description>
 </snippet>

--- a/form_validation.sublime-snippet
+++ b/form_validation.sublime-snippet
@@ -5,5 +5,6 @@
    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
    <tabTrigger>form_validation</tabTrigger>
    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-   <!-- <scope>source.php</scope> -->
+   <scope>source.php</scope>
+   <description>CI - Form Validation Rule</description>
 </snippet>

--- a/generate_table.sublime-snippet
+++ b/generate_table.sublime-snippet
@@ -14,5 +14,6 @@ echo \$this->table->generate(\$data);
    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
    <tabTrigger>generate_table</tabTrigger>
    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-   <!-- <scope>source.python</scope> -->
+   <scope>source.php, source.php.embedded.block.html</scope>
+   <description>CI - Generate Table</description>
 </snippet>

--- a/load_helper.sublime-snippet
+++ b/load_helper.sublime-snippet
@@ -6,5 +6,5 @@
     <tabTrigger>load_helper</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
     <scope>source.php</scope>
-    <description>Load Codeigniter Helper File</description>
+    <description>CI - Load Helper File</description>
 </snippet>

--- a/load_library.sublime-snippet
+++ b/load_library.sublime-snippet
@@ -1,10 +1,10 @@
 <snippet>
     <content><![CDATA[
-\$this->load->library('${1:Library Name}'${2:, \$config});
+\$this->load->library('${1:Library Name}'${2:, \$${3:config}});
 ]]></content>
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>load_library</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
     <scope>source.php</scope>
-    <description>Load Codeigniter Library</description>
+    <description>CI - Load Library</description>
 </snippet>

--- a/load_model.sublime-snippet
+++ b/load_model.sublime-snippet
@@ -6,6 +6,5 @@
     <tabTrigger>load_model</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
     <scope>source.php</scope>
-    <description>Load Model</description>
-
+    <description>CI - Load Model</description>
 </snippet>

--- a/load_view.sublime-snippet
+++ b/load_view.sublime-snippet
@@ -6,5 +6,5 @@
     <tabTrigger>load_view</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
     <scope>source.php</scope>
-    <description>Load View</description>
+    <description>CI - Load View</description>
 </snippet>

--- a/model.sublime-snippet
+++ b/model.sublime-snippet
@@ -2,10 +2,18 @@
    <content><![CDATA[
 <?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
 
-class ${1:${TM_FILENAME/(.+)\..+|.*/\u$1/:ModelName}} extends ${2:CI}_Model { }
+class ${1:${TM_FILENAME/(.+)\..+|.*/\u$1/:ModelName}} extends ${2:CI}_Model {
+
+    $0
+
+}
+
+/* End of file ${1/(.+)/\l$1/:ModelName}.php */
+/* Location: ./application/controllers/${1/(.+)/\l$1/:ModelName}.php */
 ]]></content>
    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
    <tabTrigger>model</tabTrigger>
    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-   <!-- <scope>source.python</scope> -->
+    <scope>source.php</scope>
+    <description>CI - Base Model</description>
 </snippet>

--- a/pagination.sublime-snippet
+++ b/pagination.sublime-snippet
@@ -31,5 +31,6 @@ echo \$this->pagination->create_links();
    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
    <tabTrigger>pagination</tabTrigger>
    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-   <!-- <scope>source.php</scope> -->
+    <scope>source.php</scope>
+    <description>CI - Pagination Boilerplate</description>
 </snippet>

--- a/upload.sublime-snippet
+++ b/upload.sublime-snippet
@@ -19,5 +19,6 @@ else{
    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
    <tabTrigger>upload</tabTrigger>
    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-   <!-- <scope>source.php</scope> -->
+    <scope>source.php</scope>
+    <description>CI - Upload Boilerplate</description>
 </snippet>


### PR DESCRIPTION
All snippets now have a description so they display more nicely in the command pallet
OLD:
- anchor 
- form_input
- controller

NEW:
- CI - Anchor Helper
- CI - Form Helper - Input Field
- CI - Base Controller

---

Scope is also cleared up so snippets only work in php files or php embedded in html
- Sublime tends to keep scope the same when a new file is opened so the snippets will work for a new unsaved tab in this case
