### PR TITLE
Updated scope to allow for blank files but deny from other programming languages

### DIFF
--- a/ci_start.sublime-snippet
+++ b/ci_start.sublime-snippet
@@ -10,6 +10,6 @@ $0
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>ci_start</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <!--<scope>source.php</scope>-->
+    <scope>source.php, text.html.basic, text.plain</scope>
     <description>CI - Generic Starter Class</description>
 </snippet>

--- a/controller.sublime-snippet
+++ b/controller.sublime-snippet
@@ -17,6 +17,6 @@ class ${1:${TM_FILENAME/(.+)\..+|.*/\u$1/:Controllername}} extends ${2:CI}_Contr
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>controller</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <!--<scope>source.php</scope>-->
+    <scope>source.php, text.html.basic, text.plain</scope>
     <description>CI - Base Controller</description>
 </snippet>

--- a/model.sublime-snippet
+++ b/model.sublime-snippet
@@ -14,6 +14,6 @@ class ${1:${TM_FILENAME/(.+)\..+|.*/\u$1/:ModelName}} extends ${2:CI}_Model {
    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
    <tabTrigger>model</tabTrigger>
    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <!-- <scope>source.php</scope> -->
+    <scope>source.php, text.html.basic, text.plain</scope>
     <description>CI - Base Model</description>
 </snippet>


### PR DESCRIPTION
Changed the scope of:
- model
- controller
- ci_start

to `source.php, text.html.basic, text.plain` to allow for blank files but disallow use in other programming languages.

---

I've tested these a bit and seem to be a good compromise. It probably doesn't need `source.php` in the scope but I left it in anyway. 
