### PR TITLE
Update get_post.sublime-snippet

### DIFF
--- a/get_post.sublime-snippet
+++ b/get_post.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
    <content><![CDATA[
-\$this->input->get_post()('${1:name}');
+\$this->input->get_post('${1:name}');
 ]]></content>
    <tabTrigger>_get_post</tabTrigger>
 </snippet>


### PR DESCRIPTION
extra brakets were removed. 
used to be " get_post()('name') " now " get_post('name') "
