### PR TITLE
Created a snippet to quickly create unit tests

### DIFF
--- a/unit_testing_run.sublime-snippet
+++ b/unit_testing_run.sublime-snippet
@@ -1,0 +1,14 @@
+<snippet>
+	<content><![CDATA[
+\$this->unit->run(
+	\$result = ${1},
+	\$expected = ${2:TRUE}${3:,
+	'${1}'}${4:,
+	\$result.' == '. \$expected}
+);
+]]></content>
+	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+	<tabTrigger>unit_run</tabTrigger>
+	<!-- Optional: Set a scope to limit where the snippet will trigger -->
+	<scope>source.php</scope>
+</snippet>


### PR DESCRIPTION
This is a snippet to quickly create some unit testing run code like
this:

``` php
$this->unit->run(
    $result = is_object($result),
    $expected = TRUE,
    'is_object($result)',
    $result.' == '. $expected
);
```

The  3rd and 4th parameter are optional.
