### PR TITLE
improved shortcut th

### DIFF
--- a/this.sublime-snippet
+++ b/this.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-  <content><![CDATA[\$${1:this}->$2]]></content>
+  <content><![CDATA[\$this->${1:variable}]]></content>
   <tabTrigger>th</tabTrigger>
   <scope>source.php</scope>
   <description>PHP - $this or other object use</description>


### PR DESCRIPTION
When access class object with shortcut `th` the cursor is moved to the
object `$this` that requires a new tab to move the focus to a new variable or
object you want to use. This fix improves it.
