### PR TITLE
fix missing php scope to avoid conflicts

### DIFF
--- a/flashdata.sublime-snippet
+++ b/flashdata.sublime-snippet
@@ -5,6 +5,6 @@
 	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>flashdata</tabTrigger>
 	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<!-- <scope>source.php</scope> -->
+	<scope>source.php</scope>
 	<description>CI - Flashdata</description>
 </snippet>

--- a/post.sublime-snippet
+++ b/post.sublime-snippet
@@ -3,5 +3,6 @@
 \$this->input->post('${1:name}')
 ]]></content>
 	<tabTrigger>_post</tabTrigger>
+	<scope>source.php</scope>
 	<description>CI - $_POST</description>
 </snippet>

--- a/request_headers.sublime-snippet
+++ b/request_headers.sublime-snippet
@@ -3,5 +3,6 @@
 \$this->input->request_headers()
 ]]></content>
 	<tabTrigger>request_headers</tabTrigger>
+	<scope>source.php</scope>
 	<description>CI - Request Headers</description>
 </snippet>

--- a/server.sublime-snippet
+++ b/server.sublime-snippet
@@ -3,5 +3,6 @@
 \$this->input->server('${1:name}');
 ]]></content>
 	<tabTrigger>_server</tabTrigger>
+	<scope>source.php</scope>
 	<description>CI - $_SERVER</description>
 </snippet>

--- a/set_cookie.sublime-snippet
+++ b/set_cookie.sublime-snippet
@@ -3,5 +3,6 @@
 \$this->input->set_cookie('${1:name}', '${2:value}', '${3:expire}', '${4:domain}', '${5:path}','${6:prefix}', '${7:secure}');
 ]]></content>
 	<tabTrigger>set_cookie</tabTrigger>
+	<scope>source.php</scope>
 	<description>CI - Set Cookie</description>
 </snippet>

--- a/set_flashdata.sublime-snippet
+++ b/set_flashdata.sublime-snippet
@@ -5,6 +5,6 @@
 	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>set_flashdata</tabTrigger>
 	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<!-- <scope>source.php</scope> -->
+	<scope>source.php</scope>
 	<description>CI - Set flashdata</description>
 </snippet>

--- a/user_agent.sublime-snippet
+++ b/user_agent.sublime-snippet
@@ -3,5 +3,6 @@
 \$this->input->user_agent()
 ]]></content>
 	<tabTrigger>user_agent</tabTrigger>
+	<scope>source.php</scope>
 	<description>CI - Get user agent</description>
 </snippet>

--- a/valid_ip.sublime-snippet
+++ b/valid_ip.sublime-snippet
@@ -3,5 +3,6 @@
 \$this->input->valid_ip('${1:ip}')
 ]]></content>
 	<tabTrigger>valid_ip</tabTrigger>
+	<scope>source.php</scope>
 	<description>CI - Valid IP</description>
 </snippet>


### PR DESCRIPTION
this fix avoid conflict when writing other file type like css or js. for example if you are writing a css code 

``` css
.class {
 border:1px solid
}
```

once you type `sol` for `solid` this would trigger `set_cookie` snippet which is undesirable. 
