### PR TITLE
CRUD now can be called without a php start tag

### DIFF
--- a/crud.sublime-snippet
+++ b/crud.sublime-snippet
@@ -43,6 +43,6 @@ class ${1:${TM_FILENAME/(.+)\..+|.*/\u$1/:Controllername}} extends ${2:CI}_Contr
 	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>crud</tabTrigger>
 	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>source.php</scope>
+	<scope>text.html</scope>
 	<description>CI - Simple CRUD Controller</description>
 </snippet>


### PR DESCRIPTION
Before you only can call ``crud`` in php tags and the snippet have more php tags, so now this can be called without any php tags. :smiley: 