### PR TITLE
Update form_validation.sublime-snippet, remove xss_clean

### DIFF
--- a/form_validation.sublime-snippet
+++ b/form_validation.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-\$this->form_validation->set_rules('${1:fieldname}', '${2:fieldlabel}', '${3:trim}|${4:required}|${5:min_length[${6:5}]}|${7:max_length[${8:12}]}|${9:xss_clean}');
+\$this->form_validation->set_rules('${1:fieldname}', '${2:fieldlabel}', '${3:trim}|${4:required}|${5:min_length[${6:5}]}|${7:max_length[${8:12}]}');
 ]]></content>
 	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>form_validation</tabTrigger>


### PR DESCRIPTION
the rule xss_clean while setting the form_validation rules ins't supported by CodeIgniter anymore and triggers an error as follows,
" Unable to access an error message corresponding to your field name Full XYZ.(xss_clean) "